### PR TITLE
Update lxc turnkey template for lxc 1.0 and ubuntu 14.04

### DIFF
--- a/overlay/usr/share/lxc/templates/lxc-turnkey
+++ b/overlay/usr/share/lxc/templates/lxc-turnkey
@@ -83,6 +83,18 @@ patch_rootfs() {
     echo -e "auto lo\niface lo inet loopback\n" > $interfaces
     echo -e "auto eth0\niface eth0 inet dhcp\n    hostname $hostname" >> $interfaces
 
+    info "reconfiguring locales..."
+    if [ -z "$LANG" ]; then
+        chroot $rootfs locale-gen en_US.UTF-8 UTF-8
+        chroot $rootfs update-locale LANG=en_US.UTF-8
+    else
+        encoding=$(echo $LANG | cut -d. -f2)
+        chroot $rootfs sed -e "s/^# \(${LANG} ${encoding}\)/\1/" \
+            -i /etc/locale.gen 2>/dev/null
+        chroot $rootfs locale-gen $LANG $encoding
+        chroot $rootfs update-locale LANG=$LANG
+    fi
+
     info "disabling services not required in a container..."
     chroot $rootfs /usr/sbin/update-rc.d -f udev remove
     chroot $rootfs /usr/sbin/update-rc.d -f lvm2 remove


### PR DESCRIPTION
After doing some investigation, the problem is that the newer version of lxc-create is passing the parameter '--rootfs=/var/lib/lxc/<container_name>/rootfs' to the template.  The rootfs may not always be at the default location so the template must be prepared to handle other locations.

The second issue is that on Ubuntu, the default bridge name is 'lxcbr0' and not 'br0'.  Other variations are possible on other distributions.

A third issue came up during the testing. Errors were occurring because the locale configuration was not being updated to match the host when running on Ubuntu.

I borrowed some code from the 1.04 version of the lxc-debian template to update the lxc-turnkey template and then used it to successfully install Drupal7 on my Ubuntu 14.04 laptop.  I also tested the changes on the TurnKey LXC appliance to make sure they did not cause problems there.
