### PR TITLE
more robust version seeking

### DIFF
--- a/overlay/usr/share/lxc/templates/lxc-turnkey
+++ b/overlay/usr/share/lxc/templates/lxc-turnkey
@@ -535,7 +535,7 @@ eval set -- "$OPTIONS"
 app_name="core"
 arch=$(dpkg --print-architecture)
 hostarch=${arch}
-version=$(cat /etc/turnkey_version | cut -d'-' -f3,4)
+version=$(cat /etc/turnkey_version | perl -pe 's/.*-([^-]+(-[^-]+){2})$/\1/')
 inithooks="/root/inithooks.conf"
 
 while true; do


### PR DESCRIPTION
This isn't really required here because cut will always work correctly with the LXC app. However, this particular code won't work with any of the apps with 2 part names (e.g. domain-controller) so I figure, it's good to use robust code. I robbed this from https://github.com/turnkeylinux/inithooks/blob/master/firstboot.d/29tagid#L6