### PR TITLE
Updates for 15.1 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,26 @@ containers while handling tricky details such as network routing.
 virtualization technology that powers Docker and other next generation
 software deployment platforms.
 
+Usage
+-----
+
+Creating a TurnKey LXC container is done by specifying ``turnkey`` as
+the template when invoking ``lxc-create``, for example::
+
+    # lxc-create -n CONTAINER_NAME -f CONFIG_FILE -t turnkey
+
+See the `Usage Documentation`_ for further details.
+
+Features
+--------
+
 This appliance includes all the standard features in `TurnKey Core`_, and on
 top of that:
 
 - Includes `TurnKey LXC template`_:
 
     - Download and create a container of any TurnKey appliance.
+    - Appliance version defaults to ``latest available``.
     - Insert specified inithooks.conf into container for preseeding.
     - Supports configuration of network link (e.g., br0, natbr0, none).
     - Supports configuration of apt proxy.
@@ -50,8 +64,6 @@ top of that:
       without additional configuration. This mode is not recommended for
       production systems because of security concerns.
 
-See the `Usage documentation`_ for further details.
-
 Credentials *(passwords set at first boot)*
 -------------------------------------------
 
@@ -62,5 +74,5 @@ Credentials *(passwords set at first boot)*
 .. _TurnKey LXC template: https://github.com/turnkeylinux-apps/lxc/blob/master/overlay/usr/share/lxc/templates/lxc-turnkey
 .. _nginx-proxy: https://github.com/turnkeylinux-apps/lxc/blob/master/overlay/usr/local/bin/nginx-proxy
 .. _iptables-nat: https://github.com/turnkeylinux-apps/lxc/blob/master/overlay/usr/local/bin/iptables-nat
-.. _Usage documentation: https://github.com/turnkeylinux-apps/lxc/tree/master/docs
+.. _Usage Documentation: https://github.com/turnkeylinux-apps/lxc/tree/master/docs/usage.rst
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Usage
 Creating a TurnKey LXC container is done by specifying ``turnkey`` as
 the template when invoking ``lxc-create``, for example::
 
-    # lxc-create -n CONTAINER_NAME -f CONFIG_FILE -t turnkey
+    # lxc-create -n CONTAINER_NAME -f CONFIG_FILE -t turnkey -- APPNAME [template options]
 
 See the `Usage Documentation`_ for further details.
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,14 @@
+turnkey-lxc-15.1 (1) turnkey; urgency=low
+
+  * Enhancements
+    - now compatible with ``confconsole``
+    - updated documentation
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- John Carver <dude4linux@gmail.com>  Sat, 17 Nov 2018 22:54:42 +0000
+
 turnkey-lxc-15.0 (1) turnkey; urgency=low
 
   * Update lxc to newest debian/stretch (2.0.7)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,7 +59,9 @@ configuration for the TurnKey Wordpress appliance::
     export SEC_UPDATES=FORCE
     EOF
 
-If you wish to preseed static IP addresses for a `bridged` container, include the following lines in the `wp.inithooks.conf` file. ::
+By default, containers are configured to use the built-in ``apt-cacher-ng`` listening on ``port 3142`` for a caching proxy server.  See the section, Apt Caching Proxy, below for details on how to override the setting so containers use a different apt proxy.
+
+If you wish to preseed static IP addresses for a ``bridged`` container, include the following lines in the ``wp.inithooks.conf`` file. ::
 
     export IP_CONFIG=static
     export IP_ADDRESS=XX.XX.XX.XX     # your static ip
@@ -297,7 +299,7 @@ the request to the external apt proxy.  This can be configured in one of two way
 1. If you are using pre-seeding, you can add the ``url`` of the external apt cache
    to the ``inithooks.conf`` file::
 
-    export APT_PROXY=http://[external_proxy_host_domain||external_proxy_ip]:[port]
+    export APT_PROXY=http[s]://[external_proxy_host_domain||external_proxy_ip]:[port]
 
    Note that the ``url`` must be compatible with ``apt``'s proxy specification.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,7 +4,7 @@ Usage
 Creating a TurnKey LXC container is done by specifying ``turnkey`` as
 the template when invoking ``lxc-create``, for example::
 
-    # lxc-create -n CONTAINER_NAME -f CONFIG_FILE -t turnkey
+    # lxc-create -n CONTAINER_NAME -f CONFIG_FILE -t turnkey -- APPNAME [template options]
 
 The TurnKey LXC template has required and optional arguments.
 ``lxc-create`` will pass the arguments specified after a double dash to

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -100,7 +100,7 @@ traffic to the container based on a set of rules.
 Usage: nginx-proxy
 ''''''''''''''''''
 
-The current version of nginx-proxy supports the v14.x appliances and is
+The current version of nginx-proxy supports the v14.x & v15.x appliances and is
 decoupled from lxc so it can proxy any upstream vm or container. Options
 exist which make it easier to cleanup when containers are removed and to better
 support the Ansible appliance. Templates now use the Jinja2 style, although
@@ -270,9 +270,9 @@ Now we'll remove the container, wp2, we just created.
 Apt Caching Proxy
 -----------------
 
-The LXC appliance uses `apt-cacher-ng` listening on `port 3142` for a caching
+The LXC appliance uses ``apt-cacher-ng`` listening on ``port 3142`` for a caching
 proxy server.  All containers are now configured by default to use the internal
-cache (no longer necessary to include the `-x` option on the command line).
+cache (no longer necessary to include the ``-x`` option on the command line).
 
 In some circumstances, it is desirable to use an external apt proxy.  For example,
 a small development shop with several developer workstations, a TKLdev appliance
@@ -281,19 +281,19 @@ for various stages of development and production.  To conserve bandwidth, we wan
 to have all workstations and appliances share a common apt proxy.
 
 When an external apt proxy is available, the LXC appliance will continue to configure
-all containers to use the internal `apt-cacher-ng` cache which will now forward
+all containers to use the internal ``apt-cacher-ng`` cache which will now forward
 the request to the external apt proxy.  This can be configured in one of two ways.
 
-1. If you are using preseeding, you can add the `url` of the external apt cache
-   to the `inithooks.conf` file::
+1. If you are using pre-seeding, you can add the ``url`` of the external apt cache
+   to the ``inithooks.conf`` file::
 
     export APT_PROXY=http://[external_proxy_host_domain||external_proxy_ip]:[port]
 
-   Note that the `url` must be compatible with apt's proxy specification.
+   Note that the ``url`` must be compatible with ``apt``'s proxy specification.
 
-2. In all other cases, you can add the export line above to `/root/.bashrc.d/apt-proxy`
+2. In all other cases, you can add the export line above to ``/root/.bashrc.d/apt-proxy``
    and then restart the appliance.  You can use this method if you forgot to
-   preseed, or if you want to change the external apt cache.
+   pre-seed, or if you want to change the external apt cache.
 
 
 .. _inithooks: https://www.turnkeylinux.org/docs/inithooks

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,6 +39,8 @@ the template. For example, to show the templates usage we could run::
 
         lxc-create -n core -f /etc/lxc/bridge.conf -t turnkey -- core -i /root/inithooks.conf
 
+.. note:: This document uses the domain **example.com** in accordance with IETF `RFC-2606`_. Please substitute a domain name appropriate for your local environment.
+
 Inithooks (preseeding)
 ----------------------
 
@@ -57,8 +59,7 @@ configuration for the TurnKey Wordpress appliance::
     export SEC_UPDATES=FORCE
     EOF
 
-Note, an example inithooks configuration is included in the TurnKey LXC
-appliance in the /root directory for convenience.
+.. note:: An example inithooks configuration is included in the TurnKey LXC appliance in the /root directory for convenience. Be sure to change the domain and passwords to suit your environment.
 
 Networking (bridged vs. NAT)
 ----------------------------
@@ -297,4 +298,5 @@ the request to the external apt proxy.  This can be configured in one of two way
 
 
 .. _inithooks: https://www.turnkeylinux.org/docs/inithooks
+.. _RFC-2606:   https://tools.ietf.org/html/rfc2606
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,7 +48,7 @@ An `inithooks`_ configuration must be specified in order to preseed the
 appliance on firstboot. For example, lets create an inithooks
 configuration for the TurnKey Wordpress appliance::
 
-    # cat > /root/inithooks.conf <<EOF
+    # cat > /root/wp.inithooks.conf <<EOF
     export ROOT_PASS=secretrootpass
     export DB_PASS=secretmysqlpass
     export APP_PASS=secretadminwppass
@@ -59,7 +59,16 @@ configuration for the TurnKey Wordpress appliance::
     export SEC_UPDATES=FORCE
     EOF
 
-.. note:: An example inithooks configuration is included in the TurnKey LXC appliance in the /root directory for convenience. Be sure to change the domain and passwords to suit your environment.
+If you wish to preseed static IP addresses for a `bridged` container, include the following lines in the `wp.inithooks.conf` file. ::
+
+    export IP_CONFIG=static
+    export IP_ADDRESS=XX.XX.XX.XX     # your static ip
+    export IP_NETMASK=255.255.255.0   # your netmask
+    export IP_GW=YY.YY.YY.YY          # your gateway address
+    #export IP_DNS1=DD.DD.DD.DD       # optional first dns server address
+    #export IP_DNS2=EE.EE.EE.EE       # optional second dns server address
+
+.. note:: An example inithooks configuration is included in the TurnKey LXC appliance in the /root directory for convenience. Be sure to change the domain, passwords, and addresses to suit your environment.  Uncomment the last two lines if you want to specify the optional domain name servers.
 
 Networking (bridged vs. NAT)
 ----------------------------
@@ -162,6 +171,7 @@ future versions. ::
 
 Usage: iptables-nat
 '''''''''''''''''''
+::
 
     Syntax: iptables-nat action s_port d_addr:d_port
     Add or delete iptables nat configurations
@@ -186,12 +196,11 @@ Wordpress container using the bridged network configuration.
 
 1. Create the container::
 
-    # lxc-create -n wp1 -f /etc/lxc/bridged.conf -t turnkey -- wordpress -i /root/inithooks.conf -v 15.0-stretch
+    # lxc-create -n wp1 -f /etc/lxc/bridged.conf -t turnkey -- wordpress -i /root/wp.inithooks.conf -v 15.0-stretch
 
-    This could have been shortened because -i|--inithooks now defaults to /root/inithooks.conf
-    and the version now defaults to `latest available`.:
+    This could have been shortened because the version now defaults to `latest available`.:
 
-    # lxc-create -n wp1 -f /etc/lxc/bridged.conf -t turnkey -- wordpress
+    # lxc-create -n wp1 -f /etc/lxc/bridged.conf -t turnkey -- wordpress -i /root/wp.inithooks.conf
 
 2. Start the container::
 
@@ -210,11 +219,11 @@ extra steps to expose the containers services to the network.
 
 1. Create the container::
 
-    # lxc-create -n wp2 -f /etc/lxc/natbridge.conf -t turnkey -- wordpress
+    # lxc-create -n wp2 -f /etc/lxc/natbridge.conf -t turnkey -- wordpress -i /root/wp.inithooks.conf
 
     This could have been shortened because natbridge.conf is the default config:
 
-    # lxc-create -n wp2 -t turnkey -- wordpress
+    # lxc-create -n wp2 -t turnkey -- wordpress -i /root/wp.inithooks.conf
 
 
 2. Start the container::

--- a/overlay/etc/network/interfaces
+++ b/overlay/etc/network/interfaces
@@ -1,3 +1,6 @@
+# UNCONFIGURED INTERFACES
+# remove the above line if you edit this file
+
 auto lo
 iface lo inet loopback
 

--- a/overlay/etc/network/interfaces
+++ b/overlay/etc/network/interfaces
@@ -9,6 +9,7 @@ iface eth0 inet manual
 
 auto br0
 iface br0 inet dhcp
+    hostname lxc
     bridge_ports eth0
     bridge_fd 0
     bridge_maxwait 0

--- a/overlay/root/inithooks.conf.example
+++ b/overlay/root/inithooks.conf.example
@@ -12,8 +12,9 @@ export HUB_APIKEY=SKIP
 export SEC_ALERTS=SKIP
 export SEC_UPDATES=FORCE
 
-# uncomment the following line to override default apt_proxy address
-#export APT_PROXY=PP.PP.PP.PP      # alternate apt_proxy address
+# uncomment the following line with appropriate url to override default apt_proxy address
+#export APT_PROXY=http[s]://[external_proxy_host_domain||external_proxy_ip]:[port]
+# note: the apt_proxy url must be compatible with apt's proxy specification
 
 # uncomment the following lines to specify static addressing
 #export IP_CONFIG=static           # select static mode

--- a/overlay/root/inithooks.conf.example
+++ b/overlay/root/inithooks.conf.example
@@ -1,4 +1,5 @@
 # documentation: https://www.turnkeylinux.org/docs/inithooks
+# change the passwords, domains, and addresses before first use
 
 MASTERPASS=turnkey
 
@@ -10,4 +11,14 @@ export APP_DOMAIN=DEFAULT
 export HUB_APIKEY=SKIP
 export SEC_ALERTS=SKIP
 export SEC_UPDATES=FORCE
-#export APT_PROXY=
+
+# uncomment the following line to override default apt_proxy address
+#export APT_PROXY=PP.PP.PP.PP      # alternate apt_proxy address
+
+# uncomment the following lines to specify static addressing
+#export IP_CONFIG=static           # select static mode
+#export IP_ADDRESS=XX.XX.XX.XX     # static ip address
+#export IP_NETMASK=255.255.255.0   # static netmask
+#export IP_GW=YY.YY.YY.YY          # static gateway address
+#export IP_DNS1=DD.DD.DD.DD        # optional first dns server address
+#export IP_DNS2=EE.EE.EE.EE        # optional second dns server address

--- a/overlay/usr/share/lxc/templates/lxc-turnkey
+++ b/overlay/usr/share/lxc/templates/lxc-turnkey
@@ -31,6 +31,12 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+# Usage:
+# This template is invoked by lxc-create with the --template [-t] option 'turnkey'
+#
+# Example:
+# lxc-create -n CONTAINER_NAME -f CONFIG_FILE -t turnkey -- APPNAME [template options]
+
 # Detect use under userns (unsupported)
 for arg in "$@"; do
     [ "$arg" = "--" ] && break


### PR DESCRIPTION
Closes `DNS and DHCP LXC reqeuest` https://github.com/turnkeylinux/tracker/issues/1263 and `LXC appliance improve docs to make it easier to get started` https://github.com/turnkeylinux/tracker/issues/1228.
Requires updated `confconsole` PR `Update confconsole for v15.1` https://github.com/turnkeylinux/confconsole/pull/25

I still have not found time to address the Apt Cacher NG Maintenance page available at `hostname:3142/acng-report.html`.
I had intended to add an administrative user, link the maintenance page to the user console at `hostname:80`, and document its usage. 